### PR TITLE
Parse autoincrement ids in sql response

### DIFF
--- a/asynctnt/instance.py
+++ b/asynctnt/instance.py
@@ -586,7 +586,7 @@ class TarantoolSyncInstance(TarantoolInstance):
             s.write(cmd + b'\n')
 
             data = s.read_until(b'...\n').decode()
-            data = yaml.load(data)
+            data = yaml.load(data, Loader=yaml.FullLoader)
             return data
         finally:
             s.close()

--- a/asynctnt/iproto/response.pxd
+++ b/asynctnt/iproto/response.pxd
@@ -18,6 +18,7 @@ cdef class Response:
         list _body
         bytes _encoding
         TntFields _fields
+        list _autoincrement_ids
         bint _push_subscribe
         object _exception
 

--- a/asynctnt/iproto/response.pyx
+++ b/asynctnt/iproto/response.pyx
@@ -446,7 +446,7 @@ cdef ssize_t response_parse_body(const char *buf, uint32_t buf_len,
                     arr_size = mp_decode_array(&b)
                     ids = cpython.list.PyList_New(arr_size)
                     for i in range(arr_size):
-                        el = <object> mp_decode_int(&b)
+                        el = <object>mp_decode_uint(&b)
                         cpython.Py_INCREF(el)
                         cpython.list.PyList_SET_ITEM(ids, i, el)
                     resp._autoincrement_ids = ids

--- a/asynctnt/iproto/response.pyx
+++ b/asynctnt/iproto/response.pyx
@@ -447,6 +447,7 @@ cdef ssize_t response_parse_body(const char *buf, uint32_t buf_len,
                     ids = cpython.list.PyList_New(arr_size)
                     for i in range(arr_size):
                         el = mp_decode_int(&b)
+                        cpython.Py_INCREF(el)
                         cpython.list.PyList_SET_ITEM(ids, i, el)
                     resp._autoincrement_ids = ids
                 else:

--- a/asynctnt/iproto/response.pyx
+++ b/asynctnt/iproto/response.pyx
@@ -11,6 +11,7 @@ from libc cimport stdio
 
 from asynctnt.log import logger
 
+
 @cython.final
 @cython.freelist(REQUEST_FREELIST)
 cdef class Response:

--- a/asynctnt/iproto/response.pyx
+++ b/asynctnt/iproto/response.pyx
@@ -443,7 +443,12 @@ cdef ssize_t response_parse_body(const char *buf, uint32_t buf_len,
                 if key == tarantool.SQL_INFO_ROW_COUNT:
                     resp._rowcount = mp_decode_uint(&b)
                 elif key == tarantool.SQL_INFO_AUTOINCREMENT_IDS:
-                    ids = _decode_obj(&b, resp._encoding)
+                    arr_size = mp_decode_array(&b)
+                    ids = cpython.list.PyList_New(arr_size)
+                    for i in range(arr_size):
+                        el = <object> mp_decode_int(&b)
+                        cpython.Py_INCREF(el)
+                        cpython.list.PyList_SET_ITEM(ids, i, el)
                     resp._autoincrement_ids = ids
                 else:
                     logger.warning('unknown key in sql info decoding: %d', key)

--- a/asynctnt/iproto/response.pyx
+++ b/asynctnt/iproto/response.pyx
@@ -443,12 +443,7 @@ cdef ssize_t response_parse_body(const char *buf, uint32_t buf_len,
                 if key == tarantool.SQL_INFO_ROW_COUNT:
                     resp._rowcount = mp_decode_uint(&b)
                 elif key == tarantool.SQL_INFO_AUTOINCREMENT_IDS:
-                    arr_size = mp_decode_array(&b)
-                    ids = cpython.list.PyList_New(arr_size)
-                    for i in range(arr_size):
-                        el = mp_decode_int(&b)
-                        cpython.Py_INCREF(el)
-                        cpython.list.PyList_SET_ITEM(ids, i, el)
+                    ids = _decode_obj(&b, resp._encoding)
                     resp._autoincrement_ids = ids
                 else:
                     logger.warning('unknown key in sql info decoding: %d', key)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -74,7 +74,7 @@ Tarantool config:
 
         box.execute([[
             create table users (
-                id int primary key,
+                id int primary key autoincrement,
                 name text
             )
         ]])
@@ -93,8 +93,12 @@ Python code:
         conn = asynctnt.Connection(host='127.0.0.1', port=3301)
         await conn.connect()
 
-        await conn.sql("insert into users (id, name) values (1, 'James Bond')")
-        await conn.sql("insert into users (id, name) values (2, 'Ethan Hunt')")
+        await conn.sql("insert into users (name) values ('James Bond')")
+        resp = await conn.sql("insert into users (name) values ('Ethan Hunt')")
+
+        # get value of auto incremented primary key
+        print(resp.autoincrement_ids)
+
         data = await conn.sql('select * from users')
 
         for row in data:

--- a/tests/files/app.lua
+++ b/tests/files/app.lua
@@ -122,6 +122,11 @@ if B:check_version({2, 0}) then
                 name TEXT
             )
         ]])
+        box.sql.execute([[
+            CREATE TABLE sql_space_autoincrement (
+                id INT PRIMARY KEY AUTOINCREMENT
+            )
+        ]])
     end)
 end
 

--- a/tests/files/app.lua
+++ b/tests/files/app.lua
@@ -122,9 +122,10 @@ if B:check_version({2, 0}) then
                 name TEXT
             )
         ]])
-        box.sql.execute([[
+        box.execute([[
             CREATE TABLE sql_space_autoincrement (
-                id INT PRIMARY KEY AUTOINCREMENT
+                id INT PRIMARY KEY AUTOINCREMENT,
+                name TEXT
             )
         ]])
     end)

--- a/tests/files/app.lua
+++ b/tests/files/app.lua
@@ -128,6 +128,12 @@ if B:check_version({2, 0}) then
                 name TEXT
             )
         ]])
+        box.execute([[
+            CREATE TABLE sql_space_autoincrement_multiple (
+                id INT PRIMARY KEY AUTOINCREMENT,
+                name TEXT
+            )
+        ]])
     end)
 end
 
@@ -159,6 +165,14 @@ function truncate()
 
     if box.space.SQL_SPACE ~= nil then
         box.execute('DELETE FROM sql_space')
+    end
+
+    if box.space.SQL_SPACE_AUTOINCREMENT ~= nil then
+        box.execute('DELETE FROM sql_space_autoincrement')
+    end
+
+    if box.space.SQL_SPACE_AUTOINCREMENT_MULTIPLE ~= nil then
+        box.execute('DELETE FROM sql_space_autoincrement_multiple')
     end
 end
 

--- a/tests/test_op_sql.py
+++ b/tests/test_op_sql.py
@@ -32,11 +32,24 @@ class SQLTestCase(BaseTarantoolTestCase):
         self.assertEqual(1, res.rowcount, 'rowcount ok')
 
     @ensure_version(min=(2, 0))
+    async def test__sql_empty_autoincrement(self):
+        res = await self.conn.sql(
+            "insert into sql_space (id, name) values (1, 'one')")
+        self.assertEqual(None, res.autoincrement_ids, 'autoincrement ok')
+
+    @ensure_version(min=(2, 0))
     async def test__sql_insert_autoincrement(self):
         res = await self.conn.sql(
             "insert into sql_space_autoincrement (name) values ('name')")
         self.assertEqual(1, res.rowcount, 'rowcount ok')
         self.assertEqual([1], res.autoincrement_ids, 'autoincrement ok')
+
+    @ensure_version(min=(2, 0))
+    async def test__sql_insert_autoincrement_multiple(self):
+        res = await self.conn.sql(
+            "insert into sql_space_autoincrement (name) values ('name'), ('name2')")
+        self.assertEqual(2, res.rowcount, 'rowcount ok')
+        self.assertEqual([1, 2], res.autoincrement_ids, 'autoincrement ok')
 
     @ensure_version(min=(2, 0))
     async def test__sql_insert_multiple(self):

--- a/tests/test_op_sql.py
+++ b/tests/test_op_sql.py
@@ -32,6 +32,13 @@ class SQLTestCase(BaseTarantoolTestCase):
         self.assertEqual(1, res.rowcount, 'rowcount ok')
 
     @ensure_version(min=(2, 0))
+    async def test__sql_insert_autoincrement(self):
+        res = await self.conn.sql(
+            "insert into sql_space__autoincrement values (null)")
+        self.assertEqual(1, res.rowcount, 'rowcount ok')
+        self.assertEqual([1], res.autoincrement_ids, 'autoincrement ok')
+
+    @ensure_version(min=(2, 0))
     async def test__sql_insert_multiple(self):
         res = await self.conn.sql(
             "insert into sql_space (id, name) "

--- a/tests/test_op_sql.py
+++ b/tests/test_op_sql.py
@@ -34,7 +34,7 @@ class SQLTestCase(BaseTarantoolTestCase):
     @ensure_version(min=(2, 0))
     async def test__sql_insert_autoincrement(self):
         res = await self.conn.sql(
-            "insert into sql_space__autoincrement values (null)")
+            "insert into sql_space_autoincrement (name) values ('name')")
         self.assertEqual(1, res.rowcount, 'rowcount ok')
         self.assertEqual([1], res.autoincrement_ids, 'autoincrement ok')
 

--- a/tests/test_op_sql.py
+++ b/tests/test_op_sql.py
@@ -47,7 +47,7 @@ class SQLTestCase(BaseTarantoolTestCase):
     @ensure_version(min=(2, 0))
     async def test__sql_insert_autoincrement_multiple(self):
         res = await self.conn.sql(
-            "insert into sql_space_autoincrement (name) values ('name'), ('name2')")
+            "insert into sql_space_autoincrement_multiple (name) values ('name'), ('name2')")
         self.assertEqual(2, res.rowcount, 'rowcount ok')
         self.assertEqual([1, 2], res.autoincrement_ids, 'autoincrement ok')
 


### PR DESCRIPTION
If a table has autoincrement primary key, response will have field named `autoincrement_ids` which contains generated ids.