### PR TITLE
Improvements on the sending update/upsert statements

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,40 +8,44 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
-        tarantool: ['1.10', '2']
+        tarantool: ['1.10', '2', '3']
         exclude:
           - os: macos-latest
             tarantool: '1.10'
+          - os: macos-latest
+            tarantool: '2'
+          - os: macos-latest
+            python-version: '3.7'
           - python-version: 'pypy3.10'
             tarantool: '1.10'
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Tarantool ${{ matrix.tarantool }}
+
+      - name: Install Tarantool ${{ matrix.tarantool }} on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            curl -L https://tarantool.io/nTmSHOX/release/${{ matrix.tarantool }}/installer.sh | bash
-            sudo apt-get -y install tarantool
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install tarantool
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
-          fi
+          curl -L https://tarantool.io/nTmSHOX/release/${{ matrix.tarantool }}/installer.sh | bash
+          sudo apt-get -y install tarantool
+
+      - name: Install Tarantool ${{ matrix.tarantool }} on MacOS
+        if: matrix.os == 'macos-latest'
+        run: brew install tarantool
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel coveralls
       - name: Run tests
         run: |
-          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.python-version }} == "3.12" && ${{ matrix.tarantool }} == "2" ]]; then
+          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.python-version }} == "3.12" && ${{ matrix.tarantool }} == "3" ]]; then
               make build && make test
               make clean && make debug && make coverage
               # coveralls
@@ -62,11 +66,11 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
 
       - name: Install cibuildwheel
         run: python -m pip install --upgrade cibuildwheel
@@ -92,11 +96,11 @@ jobs:
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
       - run: echo "Current tag is ${{ steps.get_tag.outputs.TAG }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -104,7 +108,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel twine build
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: wheels
@@ -133,12 +137,12 @@ jobs:
     needs:
       - test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.2.0
+**New features:**
+* Implemented ability to send update/upsert requests with field names when schema is disabled (`fetch_schema=False`) and when fields are not found in the schema (good example of this case is using json path like `data.inner1.inner2.key1` as a key)
+
+**Bug fixes:**
+* Fixed issue with not being able to send Decimals in update statements. Now there are no extra checks - any payload is sent directly to Tarantool (fixes [#34](https://github.com/igorcoding/asynctnt/issues/34))
+
+**Other changes**
+* Fixed tests failing on modern Tarantool in the SQL queries.
+* Removed from ci/cd testing on macOS python 3.7
+* Added Tarantool 3 to CI Testing
+
 ## v2.1.0
 **Breaking changes:**
 * Dropped support for Python 3.6

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ mypy:
 	$(PYTHON) -m mypy --enable-error-code ignore-without-code .
 
 ruff:
-	$(PYTHON) -m ruff .
+	$(PYTHON) -m ruff check .
 
 style-check:
 	$(PYTHON) -m black --check --diff .

--- a/asynctnt/__init__.py
+++ b/asynctnt/__init__.py
@@ -16,4 +16,4 @@ from .iproto.protocol import (
     TarantoolTuple,
 )
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/asynctnt/iproto/schema.pxd
+++ b/asynctnt/iproto/schema.pxd
@@ -21,6 +21,7 @@ cdef public class Metadata [object C_Metadata, type C_Metadata_Type]:
     cdef inline void add(self, int id, Field field)
     cdef inline str name_by_id(self, int i)
     cdef inline int id_by_name(self, str name) except *
+    cdef inline int id_by_name_safe(self, str name) except*
 
 
 cdef class SchemaIndex:

--- a/asynctnt/iproto/schema.pyx
+++ b/asynctnt/iproto/schema.pyx
@@ -51,6 +51,15 @@ cdef class Metadata:
             raise KeyError('Field \'{}\' not found'.format(name))
         return <int> <object> fld
 
+    cdef inline int id_by_name_safe(self, str name) except *:
+        cdef:
+            PyObject *fld
+
+        fld = cpython.dict.PyDict_GetItem(self.name_id_map, name)
+        if fld == NULL:
+            return -1
+        return <int> <object> fld
+
     cdef inline int len(self):
         return <int> cpython.list.PyList_GET_SIZE(self.fields)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ skip_glob = [
 
 
 [tool.ruff]
-select = [
+lint.select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
     "F",  # pyflakes
@@ -128,7 +128,7 @@ select = [
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]
-ignore = [
+lint.ignore = [
     "E501",  # line too long, handled by black
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex

--- a/tests/files/app.lua
+++ b/tests/files/app.lua
@@ -51,6 +51,14 @@ local function bootstrap()
         types = {}
     }
 
+    function b:sql_space_name(space_name)
+        if self:check_version({3, 0}) then
+            return space_name
+        else
+            return space_name:upper()
+        end
+    end
+
     function b:check_version(expected)
         return check_version(expected, self.tarantool_ver)
     end
@@ -197,16 +205,22 @@ function truncate()
     _truncate(box.space.tester)
     _truncate(box.space.no_schema_space)
 
-    if box.space.SQL_SPACE ~= nil then
-        box.execute('DELETE FROM sql_space')
-    end
+    local sql_spaces = {
+        'sql_space',
+        'sql_space_autoincrement',
+        'sql_space_autoincrement_multiple',
+    }
+    for _, sql_space in ipairs(sql_spaces) do
+        local variants = {
+            sql_space,
+            sql_space:upper(),
+        }
 
-    if box.space.SQL_SPACE_AUTOINCREMENT ~= nil then
-        box.execute('DELETE FROM sql_space_autoincrement')
-    end
-
-    if box.space.SQL_SPACE_AUTOINCREMENT_MULTIPLE ~= nil then
-        box.execute('DELETE FROM sql_space_autoincrement_multiple')
+        for _, variant in ipairs(variants) do
+            if box.space[variant] ~= nil then
+                box.execute('DELETE FROM ' .. variant)
+            end
+        end
     end
 
     _truncate(box.space.tester_ext_dec)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -123,7 +123,9 @@ class CommonTestCase(BaseTarantoolTestCase):
     async def test__read_buffer_reallocate_ok(self):
         await self.tnt_reconnect(initial_read_buffer_size=1)
 
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         try:
             res = await self.conn.call("func_param", [p])
         except Exception as e:

--- a/tests/test_op_call.py
+++ b/tests/test_op_call.py
@@ -79,12 +79,16 @@ class CallTestCase(BaseTarantoolTestCase):
             self.fail(e)
 
     async def test__call_complex_param(self):
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         res = await self.conn.call("func_param", [p])
         self.assertDictEqual(res[0][0], cmp, "Body ok")
 
     async def test__call_complex_param_bare(self):
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         cmp = [cmp]
         res = await self.conn.call("func_param_bare", [p])
         if not self.has_new_call():
@@ -177,12 +181,16 @@ class Call16TestCase(BaseTarantoolTestCase):
             self.fail(e)
 
     async def test__call16_complex_param(self):
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         res = await self.conn.call("func_param", [p])
         self.assertDictEqual(res[0][0], cmp, "Body ok")
 
     async def test__call16_complex_param_bare(self):
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         res = await self.conn.call16("func_param_bare", [p])
         self.assertDictEqual(res[0][0], cmp, "Body ok")
 

--- a/tests/test_op_eval.py
+++ b/tests/test_op_eval.py
@@ -64,7 +64,9 @@ class EvalTestCase(BaseTarantoolTestCase):
             self.fail(e)
 
     async def test__eval_complex_param(self):
-        p, cmp = get_complex_param(encoding=self.conn.encoding)
+        p, cmp = get_complex_param(
+            encoding=self.conn.encoding, replace_bin=self.conn.version < (3, 0)
+        )
         res = await self.conn.eval("return {...}", [p])
         self.assertDictEqual(res[0][0], cmp, "Body ok")
 


### PR DESCRIPTION
**New features:**
* Implemented ability to send update/upsert requests with field names when schema is disabled (`fetch_schema=False`) and when fields are not found in the schema (good example of this case is using json path like `data.inner1.inner2.key1` as a key)

**Bug fixes:**
* Fixed issue with not being able to send Decimals in update statements. Now there are no extra checks - any payload is sent directly to Tarantool (fixes #34)

**Other changes**
* Fixed tests failing on modern Tarantool in the SQL queries.